### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/contrib/check-valid-commit.py
+++ b/contrib/check-valid-commit.py
@@ -48,8 +48,8 @@ def main():
             usage()
             sys.exit(-1)
 
-    if change == None or project == None or branch == None \
-        or commit == None or patchset == None:
+    if change is None or project is None or branch is None \
+        or commit is None or patchset is None:
         usage()
         sys.exit(-1)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:gerrit?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:gerrit?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
